### PR TITLE
2.x fixes

### DIFF
--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -26,6 +26,6 @@ VOLUME     [ "/prometheus" ]
 ENTRYPOINT [ "/usr/bin/prometheus" ]
 
 CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
-             "--storage.local.path=/prometheus", \
+             "--storage.tsdb.path=/prometheus", \
              "--web.console.libraries=/usr/share/prometheus/console_libraries", \
              "--web.console.templates=/usr/share/prometheus/consoles" ]

--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -25,7 +25,7 @@ VOLUME     [ "/prometheus" ]
 
 ENTRYPOINT [ "/usr/bin/prometheus" ]
 
-CMD        [ "-config.file=/etc/prometheus/prometheus.yml", \
-             "-storage.local.path=/prometheus", \
-             "-web.console.libraries=/usr/share/prometheus/console_libraries", \
-             "-web.console.templates=/usr/share/prometheus/consoles" ]
+CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
+             "--storage.local.path=/prometheus", \
+             "--web.console.libraries=/usr/share/prometheus/console_libraries", \
+             "--web.console.templates=/usr/share/prometheus/consoles" ]

--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -25,7 +25,7 @@ VOLUME     [ "/prometheus" ]
 
 ENTRYPOINT [ "/usr/bin/prometheus" ]
 
-CMD        [ "-config.file=/etc/prometheus/prometheus.yml", \
-             "-storage.local.path=/prometheus", \
-             "-web.console.libraries=/usr/share/prometheus/console_libraries", \
-             "-web.console.templates=/usr/share/prometheus/consoles" ]
+CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
+             "--storage.tsdb.path=/prometheus", \
+             "--web.console.libraries=/usr/share/prometheus/console_libraries", \
+             "--web.console.templates=/usr/share/prometheus/consoles" ]

--- a/2.2/Dockerfile.arm
+++ b/2.2/Dockerfile.arm
@@ -49,6 +49,6 @@ VOLUME     [ "/prometheus" ]
 ENTRYPOINT [ "/usr/bin/prometheus" ]
 
 CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
-             "--storage.local.path=/prometheus", \
+             "--storage.tsdb.path=/prometheus", \
              "--web.console.libraries=/usr/share/prometheus/console_libraries", \
              "--web.console.templates=/usr/share/prometheus/consoles" ]

--- a/2.2/Dockerfile.arm
+++ b/2.2/Dockerfile.arm
@@ -48,7 +48,7 @@ VOLUME     [ "/prometheus" ]
 
 ENTRYPOINT [ "/usr/bin/prometheus" ]
 
-CMD        [ "-config.file=/etc/prometheus/prometheus.yml", \
-             "-storage.local.path=/prometheus", \
-             "-web.console.libraries=/usr/share/prometheus/console_libraries", \
-             "-web.console.templates=/usr/share/prometheus/consoles" ]
+CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
+             "--storage.local.path=/prometheus", \
+             "--web.console.libraries=/usr/share/prometheus/console_libraries", \
+             "--web.console.templates=/usr/share/prometheus/consoles" ]

--- a/2.2/Dockerfile.arm64
+++ b/2.2/Dockerfile.arm64
@@ -48,8 +48,8 @@ VOLUME     [ "/prometheus" ]
 
 ENTRYPOINT [ "/usr/bin/prometheus" ]
 
-CMD        [ "-config.file=/etc/prometheus/prometheus.yml", \
-             "-storage.local.path=/prometheus", \
-             "-web.console.libraries=/usr/share/prometheus/console_libraries", \
-             "-web.console.templates=/usr/share/prometheus/consoles" ]:x
+CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
+             "--storage.local.path=/prometheus", \
+             "--web.console.libraries=/usr/share/prometheus/console_libraries", \
+             "--web.console.templates=/usr/share/prometheus/consoles" ]:x
 

--- a/2.2/Dockerfile.arm64
+++ b/2.2/Dockerfile.arm64
@@ -49,7 +49,7 @@ VOLUME     [ "/prometheus" ]
 ENTRYPOINT [ "/usr/bin/prometheus" ]
 
 CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
-             "--storage.local.path=/prometheus", \
+             "--storage.tsdb.path=/prometheus", \
              "--web.console.libraries=/usr/share/prometheus/console_libraries", \
              "--web.console.templates=/usr/share/prometheus/consoles" ]:x
 

--- a/2.3/Dockerfile.arm
+++ b/2.3/Dockerfile.arm
@@ -49,6 +49,6 @@ VOLUME     [ "/prometheus" ]
 ENTRYPOINT [ "/usr/bin/prometheus" ]
 
 CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
-             "--storage.local.path=/prometheus", \
+             "--storage.tsdb.path=/prometheus", \
              "--web.console.libraries=/usr/share/prometheus/console_libraries", \
              "--web.console.templates=/usr/share/prometheus/consoles" ]

--- a/2.3/Dockerfile.arm
+++ b/2.3/Dockerfile.arm
@@ -48,7 +48,7 @@ VOLUME     [ "/prometheus" ]
 
 ENTRYPOINT [ "/usr/bin/prometheus" ]
 
-CMD        [ "-config.file=/etc/prometheus/prometheus.yml", \
-             "-storage.local.path=/prometheus", \
-             "-web.console.libraries=/usr/share/prometheus/console_libraries", \
-             "-web.console.templates=/usr/share/prometheus/consoles" ]
+CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
+             "--storage.local.path=/prometheus", \
+             "--web.console.libraries=/usr/share/prometheus/console_libraries", \
+             "--web.console.templates=/usr/share/prometheus/consoles" ]

--- a/2.3/Dockerfile.arm64
+++ b/2.3/Dockerfile.arm64
@@ -48,8 +48,8 @@ VOLUME     [ "/prometheus" ]
 
 ENTRYPOINT [ "/usr/bin/prometheus" ]
 
-CMD        [ "-config.file=/etc/prometheus/prometheus.yml", \
-             "-storage.local.path=/prometheus", \
-             "-web.console.libraries=/usr/share/prometheus/console_libraries", \
-             "-web.console.templates=/usr/share/prometheus/consoles" ]:x
+CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
+             "--storage.local.path=/prometheus", \
+             "--web.console.libraries=/usr/share/prometheus/console_libraries", \
+             "--web.console.templates=/usr/share/prometheus/consoles" ]:x
 

--- a/2.3/Dockerfile.arm64
+++ b/2.3/Dockerfile.arm64
@@ -49,7 +49,7 @@ VOLUME     [ "/prometheus" ]
 ENTRYPOINT [ "/usr/bin/prometheus" ]
 
 CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
-             "--storage.local.path=/prometheus", \
+             "--storage.tsdb.path=/prometheus", \
              "--web.console.libraries=/usr/share/prometheus/console_libraries", \
              "--web.console.templates=/usr/share/prometheus/consoles" ]:x
 

--- a/2.4/Dockerfile.arm
+++ b/2.4/Dockerfile.arm
@@ -49,6 +49,6 @@ VOLUME     [ "/prometheus" ]
 ENTRYPOINT [ "/usr/bin/prometheus" ]
 
 CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
-             "--storage.local.path=/prometheus", \
+             "--storage.tsdb.path=/prometheus", \
              "--web.console.libraries=/usr/share/prometheus/console_libraries", \
              "--web.console.templates=/usr/share/prometheus/consoles" ]

--- a/2.4/Dockerfile.arm
+++ b/2.4/Dockerfile.arm
@@ -48,7 +48,7 @@ VOLUME     [ "/prometheus" ]
 
 ENTRYPOINT [ "/usr/bin/prometheus" ]
 
-CMD        [ "-config.file=/etc/prometheus/prometheus.yml", \
-             "-storage.local.path=/prometheus", \
-             "-web.console.libraries=/usr/share/prometheus/console_libraries", \
-             "-web.console.templates=/usr/share/prometheus/consoles" ]
+CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
+             "--storage.local.path=/prometheus", \
+             "--web.console.libraries=/usr/share/prometheus/console_libraries", \
+             "--web.console.templates=/usr/share/prometheus/consoles" ]

--- a/2.4/Dockerfile.arm64
+++ b/2.4/Dockerfile.arm64
@@ -48,8 +48,8 @@ VOLUME     [ "/prometheus" ]
 
 ENTRYPOINT [ "/usr/bin/prometheus" ]
 
-CMD        [ "-config.file=/etc/prometheus/prometheus.yml", \
-             "-storage.local.path=/prometheus", \
-             "-web.console.libraries=/usr/share/prometheus/console_libraries", \
-             "-web.console.templates=/usr/share/prometheus/consoles" ]:x
+CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
+             "--storage.local.path=/prometheus", \
+             "--web.console.libraries=/usr/share/prometheus/console_libraries", \
+             "--web.console.templates=/usr/share/prometheus/consoles" ]:x
 

--- a/2.4/Dockerfile.arm64
+++ b/2.4/Dockerfile.arm64
@@ -49,7 +49,7 @@ VOLUME     [ "/prometheus" ]
 ENTRYPOINT [ "/usr/bin/prometheus" ]
 
 CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
-             "--storage.local.path=/prometheus", \
+             "--storage.tsdb.path=/prometheus", \
              "--web.console.libraries=/usr/share/prometheus/console_libraries", \
              "--web.console.templates=/usr/share/prometheus/consoles" ]:x
 

--- a/2.5/Dockerfile.arm
+++ b/2.5/Dockerfile.arm
@@ -49,6 +49,6 @@ VOLUME     [ "/prometheus" ]
 ENTRYPOINT [ "/usr/bin/prometheus" ]
 
 CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
-             "--storage.local.path=/prometheus", \
+             "--storage.tsdb.path=/prometheus", \
              "--web.console.libraries=/usr/share/prometheus/console_libraries", \
              "--web.console.templates=/usr/share/prometheus/consoles" ]

--- a/2.5/Dockerfile.arm
+++ b/2.5/Dockerfile.arm
@@ -48,7 +48,7 @@ VOLUME     [ "/prometheus" ]
 
 ENTRYPOINT [ "/usr/bin/prometheus" ]
 
-CMD        [ "-config.file=/etc/prometheus/prometheus.yml", \
-             "-storage.local.path=/prometheus", \
-             "-web.console.libraries=/usr/share/prometheus/console_libraries", \
-             "-web.console.templates=/usr/share/prometheus/consoles" ]
+CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
+             "--storage.local.path=/prometheus", \
+             "--web.console.libraries=/usr/share/prometheus/console_libraries", \
+             "--web.console.templates=/usr/share/prometheus/consoles" ]

--- a/2.5/Dockerfile.arm64
+++ b/2.5/Dockerfile.arm64
@@ -48,8 +48,8 @@ VOLUME     [ "/prometheus" ]
 
 ENTRYPOINT [ "/usr/bin/prometheus" ]
 
-CMD        [ "-config.file=/etc/prometheus/prometheus.yml", \
-             "-storage.local.path=/prometheus", \
-             "-web.console.libraries=/usr/share/prometheus/console_libraries", \
-             "-web.console.templates=/usr/share/prometheus/consoles" ]:x
+CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
+             "--storage.local.path=/prometheus", \
+             "--web.console.libraries=/usr/share/prometheus/console_libraries", \
+             "--web.console.templates=/usr/share/prometheus/consoles" ]:x
 

--- a/2.5/Dockerfile.arm64
+++ b/2.5/Dockerfile.arm64
@@ -49,7 +49,7 @@ VOLUME     [ "/prometheus" ]
 ENTRYPOINT [ "/usr/bin/prometheus" ]
 
 CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
-             "--storage.local.path=/prometheus", \
+             "--storage.tsdb.path=/prometheus", \
              "--web.console.libraries=/usr/share/prometheus/console_libraries", \
              "--web.console.templates=/usr/share/prometheus/consoles" ]:x
 


### PR DESCRIPTION
Hello,
since Prometheus 2.x the format of command line arguments and some of their names (in particular `--storage.*` have changed.

This PR fixes all 2.x Dockerfiles.