### PR TITLE
Switch to using resin/* base image.

### DIFF
--- a/2.4/Dockerfile.arm
+++ b/2.4/Dockerfile.arm
@@ -16,7 +16,7 @@
 # AUTHOR:         Nicolas Lamirault <nicolas.lamirault@gmail.com>
 # DESCRIPTION:    zeiot/rpi-prometheus
 
-FROM balenalib/armv7hf-debian:stretch
+FROM resin/armv7hf-debian:stretch
 
 LABEL summary="Prometheus for ARM" \
       description="Prometheus for ARM devices" \

--- a/2.4/Dockerfile.arm64
+++ b/2.4/Dockerfile.arm64
@@ -16,7 +16,7 @@
 # AUTHOR:         Nicolas Lamirault <nicolas.lamirault@gmail.com>
 # DESCRIPTION:    zeiot/rpi-prometheus
 
-FROM balenalib/aarch64-debian:stretch
+FROM resin/aarch64-debian:stretch
 
 LABEL summary="Prometheus for ARM" \
       description="Prometheus for ARM devices" \

--- a/2.5/Dockerfile.arm
+++ b/2.5/Dockerfile.arm
@@ -16,7 +16,7 @@
 # AUTHOR:         Nicolas Lamirault <nicolas.lamirault@gmail.com>
 # DESCRIPTION:    zeiot/rpi-prometheus
 
-FROM balenalib/armv7hf-debian:stretch
+FROM resin/armv7hf-debian:stretch
 
 LABEL summary="Prometheus for ARM" \
       description="Prometheus for ARM devices" \

--- a/2.5/Dockerfile.arm64
+++ b/2.5/Dockerfile.arm64
@@ -16,7 +16,7 @@
 # AUTHOR:         Nicolas Lamirault <nicolas.lamirault@gmail.com>
 # DESCRIPTION:    zeiot/rpi-prometheus
 
-FROM balenalib/aarch64-debian:stretch
+FROM resin/aarch64-debian:stretch
 
 LABEL summary="Prometheus for ARM" \
       description="Prometheus for ARM devices" \


### PR DESCRIPTION
This PR fixes #2.

It seems that current balenalib/* images have a bug that prevents
cross-building the image. The bug is caused by an ONBUILD statement that
calls `cat` binary from the image in context of host which could have a
non-ARM arch.

This patch switches all Dockerfiles based on balenalib/* images back to
resin/* images.

Signed-off-by: Tomasz Kuzemko <tomasz@kuzemko.net>